### PR TITLE
PowerSensor for SmartEnergyMeter has to be updated

### DIFF
--- a/custom_components/hilo/const.py
+++ b/custom_components/hilo/const.py
@@ -9,6 +9,6 @@ DOMAIN = "hilo"
 # with the original code, the LightSwitch is dynamically added when
 # light_as_switch boolean is enabled in configuration.
 LIGHT_CLASSES = ["LightDimmer", "WhiteBulb", "ColorBulb", "LightSwitch"]
-HILO_SENSOR_CLASSES = ["Meter", "SmokeDetector"]
+HILO_SENSOR_CLASSES = ["SmokeDetector"]
 CLIMATE_CLASSES = ["Thermostat"]
 SWITCH_CLASSES = ["LightSwitch"]


### PR DESCRIPTION
Other entities are getting updated in their own class but the
SmartEnergyMeter doesn't have any other attributes. We need to update
from the PowerSensor class. We can't update other entities from there
because it would double poll.

fixes #37