### PR TITLE
Working around Hilo's "throttling" mechanism

### DIFF
--- a/custom_components/hilo/hilo_device.py
+++ b/custom_components/hilo/hilo_device.py
@@ -44,6 +44,9 @@ class HiloBaseEntity:
 
     def _get(self, att, default=None):
         try:
-            return getattr(self.d, att)
+            value = getattr(self.d, att)
         except AttributeError:
             return default
+        if not value:
+            value = default
+        return value


### PR DESCRIPTION
Apparently, Hilo has throttled the /Attributes endpoint that returns the
current state of a device's attribute. Sometimes, it's just empty.

When it's empty, if we already have the previous states, we just skip
this polling. If we don't, we immediately retry until we get something.

Also, when I wrote the get_events for Hilo challenges, I had no real
understanding of the data structure returned. Now I do and I updated it
to at least allow us to update the sensor.

Closes #53, closes #52, closes #51